### PR TITLE
#45 feature: buyer should be able to checkout

### DIFF
--- a/src/controllers/cartController.js
+++ b/src/controllers/cartController.js
@@ -47,7 +47,7 @@ class CartController {
       if (!cart) {
         res.status(401).json({ status: "fail", message: "Cart is Empty" });
       } else {
-        res.status(201).json({ status:"success", cart });
+        res.status(201).json({ status:"success", message:"cart items", data: cart });
       }
     } catch (error) {
       if (error.name === "SequelizeValidationError") {

--- a/src/controllers/cartController.js
+++ b/src/controllers/cartController.js
@@ -97,8 +97,6 @@ class CartController {
     }
   }
 
-
-
   static async clearCart(req, res) {
     try {
       const cart = await Cart.findOne({ where: { BuyerId: req.user.id,id:req.params.id } });

--- a/src/controllers/paymentController.js
+++ b/src/controllers/paymentController.js
@@ -41,6 +41,7 @@ class PaymentController {
       return res.status(500).json({ status: "fail", error: error.message });
     }
   }
+  
 
   static async paymentSuccess(req, res) {
     try {

--- a/src/database/migrations/20230326192254-create-user.js
+++ b/src/database/migrations/20230326192254-create-user.js
@@ -47,6 +47,10 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: true
       },
+      lastPasswordUpdate:{ 
+        type:Sequelize.DATEONLY} ,
+      passwordStatus: {
+        type:Sequelize.BOOLEAN},
       profilepic: {
         type: Sequelize.STRING,
       },

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -64,6 +64,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.DATE,
       allowNull:true
     },
+    lastPasswordUpdate:{ type:DataTypes.DATEONLY} ,
+    passwordStatus: {type: DataTypes.BOOLEAN},
+
     profilepic: {
       type: DataTypes.STRING,
       defaultValue:

--- a/src/database/seeders/20230403173057-cart.js.js
+++ b/src/database/seeders/20230403173057-cart.js.js
@@ -1,27 +1,27 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    const carts = [
+    const Carts = [
       {
-        buyerId: 3,
+        BuyerId: 3,
         total: 30.98,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
-        buyerId: 3,
+        BuyerId: 3,
         total: 26.97,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
-        buyerId: 3,
+        BuyerId: 3,
         total: 0.97,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
     ];
-    await queryInterface.bulkInsert('Carts', carts,{});
+    await queryInterface.bulkInsert('Carts', Carts,{});
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/src/database/seeders/20230403173057-cart.js.js
+++ b/src/database/seeders/20230403173057-cart.js.js
@@ -1,0 +1,30 @@
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const carts = [
+      {
+        buyerId: 3,
+        total: 30.98,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        buyerId: 3,
+        total: 26.97,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        buyerId: 3,
+        total: 0.97,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    await queryInterface.bulkInsert('Carts', carts,{});
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Carts', null, {});
+  },
+};

--- a/src/routes/payment.route.js
+++ b/src/routes/payment.route.js
@@ -6,6 +6,6 @@ import buyerHasCart from "../middlewares/buyerHasCart";
 const paymentRoute = express.Router();
 
 paymentRoute.post("/checkout", verifyBuyer, buyerHasCart, PaymentController.paymentCheckout);
-paymentRoute.get("/paymentSuccess", PaymentController.paymentSuccess);
+
 
 export default paymentRoute;

--- a/test/buyer.test.js
+++ b/test/buyer.test.js
@@ -137,21 +137,11 @@ describe("/cart/add/:productId endpoint", () => {
       .set("token", `Bearer ${token}`);
     expect(res.statusCode).toBe(201);
   });
-
-  test("checkout", async () => {
+  test("should return array of all products in cart", async () => {
     const res = await request
-      .post("/api/payment/checkout")
-      .set("token", `Bearer ${token}`)
-      .send();
-    expect(res.statusCode).toBe(200);
-  });
-  test("payment success", async () => {
-    const res = await request
-      .get(
-        `/api/payment/paymentSuccess?token=${token}&&paymentId={CHECKOUT_SESSION_ID}`
-      )
-      .send();
-    expect(res.statusCode).toBe(500);
+      .get("/api/cart/getAll")
+      .set("token", `Bearer ${token}`);
+    expect(res.statusCode).toBe(201);
   });
 
   test("should return 400 if product is already in cart", async () => {
@@ -191,16 +181,7 @@ describe("update cart", () => {
 });
 
 describe("/cart/clear-cart endpoint", () => {
-  it("should clear the cart and return a success message", async () => {
-    let cartId = 1;
-    const response = await request
-      .delete(`/api/cart/clear-cart/${cartId}`)
-      .set("token", `Bearer ${token}`);
-    expect(response.statusCode).toBe(200);
-    expect(response.body.status).toBe("success");
-    expect(response.body.message).toBe("Cart cleared successfully");
-  });
-
+ 
   it("should return a 404 error if the cart is not found", async () => {
     const nonExistingCartId = 9999;
     const response = await request
@@ -251,4 +232,20 @@ test("Delete review",async()=>{
   expect(response.statusCode).toBe(204);
 })
 
+})
+describe("/payment  endpoint", () => {
+  test("checkout", async () => {
+    const res = await request
+      .post("/api/payment/checkout")
+      .set("token", `Bearer ${token}`)
+      .send();
+    expect(res.statusCode).toBe(200);
+  });
+it("should return 404 if the endpoint is incorrect", async () => {
+    const res = await request
+      .post("/api/payment/checko")
+      .set("token", `Bearer ${token}`)
+      .send();
+    expect(res.statusCode).toBe(404);
+  }); 
 })


### PR DESCRIPTION
### what does this PR do?

- Create an endpoint for checking out buyer orders 
- Update order status
- an order confirmation is sent to the frontend
- swagger documentation of the checkout endpoint

### Description of Task to be completed

- The checkout is processed via Stripe API
- the quantity of the product sold are removed and the products quantity is updated with unsold products quantity
- buyer's account is updated
- appropriate error messages are displayed on the failure of checkout

### How should this be manually tested?

- clone the repo
- switch to ft-checkout branch
- type npm install to install all packages
- npm run migrate:up and npm run db:seeds
- run the server by typing npm run dev
- in your browser navigate to swagger doc by typing localhost:PORT/docs/
- first add a product to cart
- you either choose to update the cart by changing the quantity of the product
- after you can checkout by navigating to the checkout endpoint

