### PR TITLE
fix:create buyer's checkout and payment

### DIFF
--- a/src/api-docs/product.docs.js
+++ b/src/api-docs/product.docs.js
@@ -139,6 +139,11 @@ const searchProduct = {
 const getProductById = {
   tags: ["Product"],
   description: "get product from seller collection",
+  security: [
+    {
+      token: []
+    }
+  ],
   parameters: [
     {
       name: "id",

--- a/src/api-docs/user.logout.docs.js
+++ b/src/api-docs/user.logout.docs.js
@@ -3,6 +3,11 @@ module.exports={
         "get": {
           "tags": ["Users"],
           "description": "Logout a user from app",
+          "security": [
+            {
+              "token": []
+            }
+          ],
           "responses": {
             "200": {
               "description": "User logged out successfully"

--- a/src/controllers/Oauthcontroller.js
+++ b/src/controllers/Oauthcontroller.js
@@ -6,7 +6,7 @@ import passport from "passport";
 import { Strategy as GoogleStrategy } from "passport-google-oauth20";
 import dotenv from "dotenv";
 import connectDb from "../database/connectDb";
-import { User as user } from "../database/models";
+import { User as user ,Role,Permission } from "../database/models";
 
 import { generateAccessToken } from "../utils/helpers/generateToken";
 
@@ -34,13 +34,19 @@ passport.use(
           RoleId: 3
         };
 
+
+        const existingRole = await Role.findByPk(userInfo.RoleId, {
+          include: { model: Permission }
+        });
+        const roles = existingRole.toJSON();
+
         const [User, created] = await user.findOrCreate({
           where: { googleId: profile.id },
           defaults: userInfo
         });
         const token = await generateAccessToken({
           id: User.id,
-          roleId: User.roleId
+          role:roles,
         });
         User.token = token;
         if (created) return cb(null, User);

--- a/src/middlewares/checklogin.js
+++ b/src/middlewares/checklogin.js
@@ -2,11 +2,12 @@
 
 import { decodeAccessToken } from '../utils/helpers/generateToken';
 
-const isLoggedIn = async (req, res, next) => {
-  const {token} = req.signedCookies; 
-  if (!token) {
-    return  res.status(401).json({  status:req.t("fail") , Error:req.t("Error")});
-  }
+const isLoggedIn = async (req, res, next) => { 
+  const authHeader = req.headers.token;
+    if (!authHeader) {
+      return  res.status(401).json({  status:req.t("fail") , Error:req.t("Error")});
+    }
+    const token = authHeader.split(" ")[1];
   try {
     const user = await decodeAccessToken(token);
     if (!user) {
@@ -17,6 +18,7 @@ const isLoggedIn = async (req, res, next) => {
   } catch(error) {
     return error;
   }
+ 
 };
 
 export default isLoggedIn;

--- a/src/routes/Oauthroute.js
+++ b/src/routes/Oauthroute.js
@@ -22,11 +22,7 @@ try {
     passport.authenticate("google", { session: false }),
     (req, res) => {
       const {token} = req.user;
-      res.cookie("token", token, {
-        secure:false,
-        httpOnly:true,
-        sameSite:'lax' ,signed:true       
-      });
+      res.cookie("token", token);
       res.redirect(`${process.env.REDIRECT_URL}`);
     }
   );

--- a/src/routes/product.route.js
+++ b/src/routes/product.route.js
@@ -1,6 +1,5 @@
 import express from "express";
 import ProductController from "../controllers/productController";
-import isLoggedIn from "../middlewares/checklogin";
 import uploadImages from "../middlewares/uploadImage";
 import { productExistAlready,IsProductExist } from "../middlewares/productExists";
 import { productSchema, updateSchema } from "../validations/validateProduct";
@@ -14,7 +13,7 @@ const productRoute = express.Router();
 productRoute.get("/searcch", ProductController.searchProduct);
 productRoute.get("/getAll",verifyVendor, ProductController.getAllProducts);
 productRoute.get("/getAvailable",ProductController.getAvailableProduct);
-productRoute.get("/getOne/:id", isLoggedIn, ProductController.getProductById);
+productRoute.get("/getOne/:id", ProductController.getProductById);
 productRoute.post("/addToWishlist/:productId",verifyBuyer,checkPassword,ProductController.addToWishlist);
 productRoute.get("/retrieveWishlistItems",verifyBuyer,ProductController.retrieveProductItems);
 productRoute.get("/recommended", ProductController.getRecommendedProducts);

--- a/src/utils/helpers/generateToken.js
+++ b/src/utils/helpers/generateToken.js
@@ -4,7 +4,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const generateAccessToken = async (paramsObject) => {
-  const token = jwt.sign(paramsObject, process.env.JWT_SECRET, { expiresIn: '1h' });
+  const token = jwt.sign(paramsObject, process.env.JWT_SECRET, { expiresIn: '30h' });
   return token;
 };
 

--- a/test/buyer.test.js
+++ b/test/buyer.test.js
@@ -103,7 +103,7 @@ describe("testing signin email and password", () => {
   it("should log out user and clear token cookie", async () => {
     const response = await request
       .get("/api/user/logout")
-      .set("Cookie", cookie);
+      .set("token", `Bearer ${token}`);
     expect(response.status).toBe(200);
     expect(response.body.status).toBe("success");
     expect(response.body.message).toBe("User logged out successfully");
@@ -256,7 +256,7 @@ describe("chats endpoint", () => {
   it("should getallchat and return a success message", async () => {
     const response = await request
       .get("/api/chat/get-all-chat")
-      .set("Cookie", cookie);
+      .set("token", `Bearer ${token}`);
     expect(response.statusCode).toBe(200);
     expect(response.body.status).toBe("success");
   });
@@ -266,14 +266,14 @@ describe("testing get specific item", () => {
   test("should return 404 if product not found", async () => {
     const res = await request
       .get(`/api/product/getOne/${9000}`)
-      .set("Cookie", cookie);
+      .set("token", `Bearer ${token}`);
     expect(res.statusCode).toBe(404);
     expect(res.body.status).toBe("fail");
   });
   test("should get specific item", async () => {
     const res = await request
       .get(`/api/product/getOne/${2}`)
-      .set("Cookie", cookie);
+      .set("token", `Bearer ${token}`);
     expect(res.statusCode).toBe(200);
     expect(res.body.status).toBe("success");
   });

--- a/test/buyer.test.js
+++ b/test/buyer.test.js
@@ -266,14 +266,12 @@ describe("testing get specific item", () => {
   test("should return 404 if product not found", async () => {
     const res = await request
       .get(`/api/product/getOne/${9000}`)
-      .set("token", `Bearer ${token}`);
     expect(res.statusCode).toBe(404);
     expect(res.body.status).toBe("fail");
   });
   test("should get specific item", async () => {
     const res = await request
       .get(`/api/product/getOne/${2}`)
-      .set("token", `Bearer ${token}`);
     expect(res.statusCode).toBe(200);
     expect(res.body.status).toBe("success");
   });

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -41,12 +41,6 @@ describe("testing wrong route for getting available items", () => {
     expect(res.statusCode).toBe(404);
   });
 });
-describe("testing get specific item", () => {
-  test("get specific item", async () => {
-    const res = await request(app).get(`/api/product/getOne/${id}`);
-    expect(res.statusCode).toBe(401);
-  });
-});
 describe("testing get all items", () => {
   test("get all items it should return 401", async () => {
     const res = await request(app).get("/api/product/getAll");


### PR DESCRIPTION
#### What does this PR do?
- fix create buyer's checkout and payment
- fix sending successful confirmation to the frontend

#### Description of Task to be completed
- i made a change to send successful confirmation to the frontend. from `success_url: ${appUrl}/api/payment/paymentSuccess?token=${token}&&paymentId={CHECKOUT_SESSION_ID}`. to ` success_url: ${process.env.REDIRECT_URL}?token=${token}&&paymentId={CHECKOUT_SESSION_ID}&&amount=${amountpaid}`
#### How should this be manually tested?
- clone the repo
- switch to `fix-create-payment`
- type `npm install` to install all packages
- run the server by typing `npm run dev`
- in your browser navigate to swagger doc by typing localhost:PORT/docs/
- first add a product to cart
- after you can checkout by navigating to the checkout endpoint
- copy the URL provided and past it in the browser to process the payment